### PR TITLE
Fix #62 URL language identification

### DIFF
--- a/util.py
+++ b/util.py
@@ -121,6 +121,7 @@ def getCoverages(text, modes, penalize=False):
 def getCoverage(text, mode, modeDir, penalize=False):
     analysis = apertium(text, mode, modeDir)
     lexicalUnits = removeDotFromDeformat(text, re.findall(r'\^([^\$]*)\$([^\^]*)', analysis))
+    # tries to handle URLs, see goavki PR #67
     analyzedLexicalUnits = list(filter(lambda x: not x[0].split('/')[(x[0].count('/') + 1) // 2][0] in '*&#', lexicalUnits))
     if len(lexicalUnits) and not penalize:
         return len(analyzedLexicalUnits) / len(lexicalUnits)

--- a/util.py
+++ b/util.py
@@ -121,7 +121,7 @@ def getCoverages(text, modes, penalize=False):
 def getCoverage(text, mode, modeDir, penalize=False):
     analysis = apertium(text, mode, modeDir)
     lexicalUnits = removeDotFromDeformat(text, re.findall(r'\^([^\$]*)\$([^\^]*)', analysis))
-    analyzedLexicalUnits = list(filter(lambda x: not x[0].split('/')[1][0] in '*&#', lexicalUnits))
+    analyzedLexicalUnits = list(filter(lambda x: not x[0].split('/')[(x[0].count('/') + 1) // 2][0] in '*&#', lexicalUnits))
     if len(lexicalUnits) and not penalize:
         return len(analyzedLexicalUnits) / len(lexicalUnits)
     elif len(lexicalUnits) and len(text) and penalize:


### PR DESCRIPTION
The coverage calculator was `split`ting each word of the analyzed text at the first forward slash, so that the part after the slash could be checked for *&# characters. When `//` appeared in a word, like a URL, this caused problems with checking an empty string.

The fix makes it check not the part immediately after the first slash but the part after the 'middle' slash, where 'middle' is the ((n+1)/2)th slash if there are n slashes in total. The reasoning is that if there are slashes within a word, they will be preserved in the lemma of the analysis, or they will simply appear with *&#, so they will always appear and the above counting works.

If a word has multiple ambiguous analyses separated by slashes then the fix makes it check the 'middle' analysis, which isn't an issue: if multiple analyses exist then none of them will start with *&# (am I correct in assuming this?) and it should be counted as positive coverage.