### PR TITLE
Added support for handling multiple q parameters

### DIFF
--- a/servlet.py
+++ b/servlet.py
@@ -504,7 +504,6 @@ class TranslateHandler(BaseHandler):
         self.response = []
         query_list = self.get_arguments('q')
         langpair = self.get_argument('langpair')
-        
         for query in query_list:
             pair = self.getPairOrError(langpair, len(query))
             if pair is not None:


### PR DESCRIPTION
Currently, APy doesn't support multiple q's as parameters when given for translation. I have resolved this by storing multiple responses(local) first and then sending all at once in a global response. Each parameter q is iteratively translated by a given langpair and an error is raised if at least one of the translation fails.

refs #86 