### PR TITLE
Build and remove langNames.db during install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ class InstallHelper(install):
             check_call(['make', 'langNames.db'])
         except CalledProcessError:
             pass
-        install.run(self)
+        super().run(self)
         try:
             check_call(['make', 'clean'])
         except CalledProcessError:
@@ -54,7 +54,7 @@ setup(
         'console_scripts': ['apertium-apy=apertium_apy.apy:main'],
     },
     packages=find_packages(),
-    cmdclass=dict(
-        install=InstallHelper,
-    ),
+    cmdclass={
+        'install': InstallHelper,
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from subprocess import check_call, CalledProcessError
 
 from apertium_apy import apy
 
+
 class InstallHelper(install):
     def run(self):
         try:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,21 @@
 from os import path
 from setuptools import setup, find_packages
+from setuptools.command.install import install
+from subprocess import check_call, CalledProcessError
 
 from apertium_apy import apy
+
+class InstallHelper(install):
+    def run(self):
+        try:
+            check_call(['make', 'langNames.db'])
+        except CalledProcessError:
+            pass
+        install.run(self)
+        try:
+            check_call(['make', 'clean'])
+        except CalledProcessError:
+            pass
 
 setup(
     name='apertium-apy',
@@ -38,4 +52,7 @@ setup(
         'console_scripts': ['apertium-apy=apertium_apy.apy:main'],
     },
     packages=find_packages(),
+    cmdclass=dict(
+        install=InstallHelper,
+    ),
 )

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ class InstallHelper(install):
         except CalledProcessError:
             pass
 
+
 setup(
     name='apertium-apy',
     version=apy.__version__,


### PR DESCRIPTION
Weirdly enough, setuptools does not allow extending the build or clean commands directly, so one has to do the work in install. This should fix issue #84.