### PR TITLE
WIP issue #84

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,12 @@ test:
 	coverage combine
 	coverage report --fail-under 40
 
+unclean: langNames.db
+	cp -a langNames.db README.md COPYING apertium_apy/
+
 clean:
 	rm -f langNames.db
+	rm -f apertium_apy/langNames.db apertium_apy/README.md apertium_apy/COPYING
 
 distclean: clean
 	rm -rf dist/ build/ *.egg-info/ .mypy_cache/ .coverage

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from os import listdir, path
+from os import path
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 from subprocess import check_call, CalledProcessError
@@ -9,7 +9,7 @@ from apertium_apy import apy
 class InstallHelper(install):
     def run(self):
         try:
-            check_call(['make', 'langNames.db'])
+            check_call(['make', 'unclean'])
         except CalledProcessError:
             pass
 
@@ -19,13 +19,6 @@ class InstallHelper(install):
             check_call(['make', 'clean'])
         except CalledProcessError:
             pass
-
-
-def files(root):
-    for file_or_dir in listdir(root):
-        full_path = path.join(root, file_or_dir)
-        if path.isfile(full_path):
-            yield full_path
 
 
 setup(
@@ -64,13 +57,9 @@ setup(
         'console_scripts': ['apertium-apy=apertium_apy.apy:main'],
     },
     packages=find_packages(exclude=['tests']),
-    data_files=[
-        ('apertium_apy', ['README.md', 'COPYING', 'langNames.db']),
-        ('apertium_apy/tools', files('tools')),
-        ('apertium_apy/tools/systemd', files('tools/systemd')),
-        ('apertium_apy/tools/sysvinit', files('tools/sysvinit')),
-        ('apertium_apy/tools/upstart', files('tools/upstart')),
-    ],
+    package_data={
+        'apertium_apy': ['README.md', 'COPYING', 'langNames.db'],
+    },
     cmdclass={
         'install': InstallHelper,
     },


### PR DESCRIPTION
Install step install_data puts the extra files into /usr/apertium_apy instead of /usr/lib/python3.6/dist-packages/apertium_apy or /usr/share/apertium-apy

It's a known bug https://github.com/pypa/setuptools/issues/130 , and it's even marked wontfix with this comment https://github.com/pypa/setuptools/issues/130#issuecomment-345522681 :
> the plan to deprecate easy_install and setuptools' mechanisms for installing packages

As per https://setuptools.readthedocs.io/en/latest/setuptools.html#including-data-files if one uses
````
    package_data={
        'apertium_apy': ['README.md', 'COPYING', 'langNames.db'],
    },
````
then those files are included, but they must first exist in the apertium_apy folder (which the make step can make sure they do).

How to include tools/ is left as an exercise to the reader - meaning, I don't see why they make sense in the Python folder, and I don't want to fight this absurdity of a tool.