### PR TITLE
Added Support for handling multiple 'q' parameters

### DIFF
--- a/apertium_apy/handlers/base.py
+++ b/apertium_apy/handlers/base.py
@@ -132,7 +132,9 @@ class BaseHandler(tornado.web.RequestHandler):
             self._write_buffer.append(utf8('%s(%s)' % (self.callback, data)))
         else:
             self._write_buffer.append(utf8(data))
-        self.finish()
+
+        if not self._finished:
+            self.finish()
 
     def write_error(self, status_code, **kwargs):
         http_explanations = {


### PR DESCRIPTION
Currently, APy doesn't support multiple q's as parameters when given for translation. I have resolved this by storing multiple responses(local) first and then sending all at once in a global response. Each parameter q is iteratively translated by a given langpair and an error is raised if at least one of the translation fails.

refs #86 