### PR TITLE
Allowing keys to be passed as a json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# pycharm conf files
+.idea/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ of the following packages:
 - `requests` enables suggestion handling
 - `chromium_compact_language_detector` enables improved language detection (cld2)
 - `chardet` enables website character encoding detection
+- `commentjson` allows to keep API keys in commented json
 
 Precise versions are available in `requirements.txt` and `setup.py`.
 
@@ -62,6 +63,7 @@ Installation through `apt` or `pip` adds an `apertium-apy` executable:
                     [-M UNKNOWN_MEMORY_LIMIT] [-T STAT_PERIOD_MAX_AGE]
                     [-wp WIKI_PASSWORD] [-wu WIKI_USERNAME] [-b]
                     [-rs RECAPTCHA_SECRET] [-md MAX_DOC_PIPES] [-C CONFIG]
+                    [-ak API_KEYS_FILE]
                     pairs_path
 
     Apertium APY -- API server for machine translation and language analysis
@@ -136,6 +138,7 @@ Installation through `apt` or `pip` adds an `apertium-apy` executable:
                             allow (default = 3)
     -C CONFIG, --config CONFIG
                             Configuration file to load options from
+    -ak, --api-keys         JSON file where API keys are stored. Comments are allowed
 
 Contributing
 ------------

--- a/apertium_apy/apy.py
+++ b/apertium_apy/apy.py
@@ -88,7 +88,8 @@ class GetLocaleHandler(BaseHandler):
 def setup_handler(
     port, pairs_path, nonpairs_path, lang_names, missing_freqs_path, timeout,
     max_pipes_per_pair, min_pipes_per_pair, max_users_per_pipe, max_idle_secs,
-    restart_pipe_after, max_doc_pipes, verbosity=0, scale_mt_logs=False, memory=1000,
+    restart_pipe_after, max_doc_pipes, verbosity=0, scale_mt_logs=False,
+    memory=1000, apy_keys=None,
 ):
 
     global missing_freqs_db
@@ -106,6 +107,7 @@ def setup_handler(
     handler.scale_mt_logs = scale_mt_logs
     handler.verbosity = verbosity
     handler.doc_pipe_sem = Semaphore(max_doc_pipes)
+    handler.api_keys_conf = apy_keys
 
     modes = search_path(pairs_path, verbosity=verbosity)
     if nonpairs_path:
@@ -221,6 +223,7 @@ def parse_args(cli_args=sys.argv[1:]):
     parser.add_argument('-md', '--max-doc-pipes',
                         help='how many concurrent document translation pipelines we allow (default = 3)', type=int, default=3)
     parser.add_argument('-C', '--config', help='Configuration file to load options from', default=None)
+    parser.add_argument('-ak', '--api-keys', help='Configuration file to load API keys', default=None)
 
     args = parser.parse_args(cli_args)
 
@@ -270,7 +273,8 @@ def setup_application(args):
 
     setup_handler(args.port, args.pairs_path, args.nonpairs_path, args.lang_names, args.missing_freqs, args.timeout,
                   args.max_pipes_per_pair, args.min_pipes_per_pair, args.max_users_per_pipe, args.max_idle_secs,
-                  args.restart_pipe_after, args.max_doc_pipes, args.verbosity, args.scalemt_logs, args.unknown_memory_limit)
+                  args.restart_pipe_after, args.max_doc_pipes, args.verbosity, args.scalemt_logs,
+                  args.unknown_memory_limit, args.api_keys)
 
     handlers = [
         (r'/', RootHandler),

--- a/apertium_apy/handlers/base.py
+++ b/apertium_apy/handlers/base.py
@@ -26,6 +26,7 @@ class BaseHandler(tornado.web.RequestHandler):
     timeout = None
     scale_mt_logs = False
     verbosity = 0
+    api_keys_conf = None
 
     # dict representing a graph of translation pairs; keys are source languages
     # e.g. pairs_graph['eng'] = ['fra', 'spa']

--- a/apertium_apy/handlers/translate.py
+++ b/apertium_apy/handlers/translate.py
@@ -8,7 +8,7 @@ from tornado import gen
 
 from apertium_apy import missing_freqs_db  # noqa: F401
 from apertium_apy.handlers.base import BaseHandler
-from apertium_apy.keys import ApiKey
+from apertium_apy.keys import ApiKeys
 from apertium_apy.utils import to_alpha3_code, scale_mt_log
 from apertium_apy.utils.translation import parse_mode_file, make_pipeline
 
@@ -192,6 +192,6 @@ class TranslateHandler(BaseHandler):
     @classmethod
     def get_api_key(cls, key):
         if not cls.api_keys:
-            cls.api_keys = ApiKey(cls.api_keys_conf)
+            cls.api_keys = ApiKeys(cls.api_keys_conf)
 
         return cls.api_keys.get_key(key)

--- a/apertium_apy/keys.py
+++ b/apertium_apy/keys.py
@@ -1,14 +1,33 @@
+import logging
+
+try:
+    from commentjson import loads as jsonload
+except ImportError:
+    from json import loads as jsonload
+
+import os
 from collections import defaultdict
 
 if False:
     from typing import Dict  # noqa: F401
 
 
-def get_key(key):
-    return keys[key]
+class ApiKey:
+    def __init__(self, api_keys_conf):
+        keys_raw = {
+            # add keys here
+        }  # type: Dict
 
+        if api_keys_conf and os.path.isfile(api_keys_conf):
+            logging.info('Loading keys from %s' % api_keys_conf)
 
-keys_raw = {
-    # add keys here
-}  # type: Dict
-keys = defaultdict(lambda: 'null', keys_raw)
+            with open(api_keys_conf) as handle:
+                try:
+                    keys_raw = jsonload(handle.read())
+                except Exception:
+                    logging.warning('Could not read keys from %s' % api_keys_conf)
+
+        self.keys = defaultdict(lambda: 'null', keys_raw)
+
+    def get_key(self, key):
+        return self.keys[key]

--- a/apertium_apy/keys.py
+++ b/apertium_apy/keys.py
@@ -12,7 +12,7 @@ if False:
     from typing import Dict  # noqa: F401
 
 
-class ApiKey:
+class ApiKeys:
     def __init__(self, api_keys_conf):
         keys_raw = {
             # add keys here

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ idna==2.6
 requests==2.18.4
 tornado==4.2.1
 urllib3==1.22
+commentjson==0.7.1

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'suggestions': ['requests'],
         'website_encoding_detect': ['chardet'],
         'lang_detect': ['chromium_compact_language_detector'],
-        'full': ['apertium-streamparser', 'requests', 'chardet', 'chromium_compact_language_detector'],
+        'full': ['apertium-streamparser', 'requests', 'chardet', 'chromium_compact_language_detector', 'commentjson'],
     },
     entry_points={
         'console_scripts': ['apertium-apy=apertium_apy.apy:main'],


### PR DESCRIPTION
This feature will enable using apertium-apy installed with PIP and still use api-keys, as that feature will no longer depend on modifying a package's source file.