### PR TITLE
Redir of stderr/-out not enough, use logging.basicConfig(filename=…)

### DIFF
--- a/apertium_apy/apy.py
+++ b/apertium_apy/apy.py
@@ -297,13 +297,14 @@ def setup_application(args):
 
     return tornado.web.Application(handlers)
 
+
 def setup_logging(args):
     if args.daemon:
         # regular content logs are output stderr
         # python messages are mostly output to stdout
         # hence swapping the filenames?
-        logfile=os.path.join(args.log_path, 'apertium-apy.log')
-        errfile=os.path.join(args.log_path, 'apertium-apy.err')
+        logfile = os.path.join(args.log_path, 'apertium-apy.log')
+        errfile = os.path.join(args.log_path, 'apertium-apy.err')
         sys.stderr = open(logfile, 'a+')
         sys.stdout = open(errfile, 'a+')
         logging.basicConfig(filename=logfile, filemode='a')  # NB. Needs to happen *before* we use logs for anything
@@ -320,6 +321,7 @@ def setup_logging(args):
         if args.daemon:
             logging.getLogger('tornado.access').propagate = False
     enable_pretty_logging()
+
 
 def main():
     check_utf8()


### PR DESCRIPTION
Also, the basicConfig stuff needs to happen before any loggers are
created, otherwise it has no effect (or you have to pass in the
created loggers to basicConfig, which sounds like a drag).

Fixes #112 - apertium-apy doesn't honor -P / --log-path