### PR TITLE
Add language_names/ to dist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include COPYING
 include langNames.db
 include servlet.py
+include language_names/*
 recursive-include tools *


### PR DESCRIPTION
With this commit, “make dist” includes the files under `language_names/` in the tarball under `dist/`.