### PR TITLE
Added fix for broken links

### DIFF
--- a/apertium_apy/handlers/translate_webpage.py
+++ b/apertium_apy/handlers/translate_webpage.py
@@ -19,7 +19,8 @@ from apertium_apy.handlers.translate import TranslateHandler
 
 
 class TranslateWebpageHandler(TranslateHandler):
-    def url_repl(self, base, attr, quote, aurl):
+    def url_repl(self, base, attr, quote, aurl)
+        aurl = urljoin(base.path, aurl)
         a = urlparse(aurl)
         if a.netloc == '':
             newurl = urlunsplit((base.scheme,

--- a/apertium_apy/handlers/translate_webpage.py
+++ b/apertium_apy/handlers/translate_webpage.py
@@ -4,7 +4,7 @@ import os
 import re
 import time
 from hashlib import sha1
-from urllib.parse import urlparse, urlunsplit
+from urllib.parse import urlparse, urlunsplit, urljoin
 
 from tornado import gen
 from tornado import httpclient


### PR DESCRIPTION
Broken links and images were showing due to relative pathes being used and not being rebased properly. Fixed by joining the url and the base path.