### PR TITLE
tornado6 deprecated web.asynchronous; use gen.coroutine instead

### DIFF
--- a/apertium_apy/gateway.py
+++ b/apertium_apy/gateway.py
@@ -14,6 +14,7 @@ from collections import OrderedDict
 import tornado
 import tornado.httpclient
 import tornado.httpserver
+import tornado.gen
 import tornado.web
 from tornado.options import enable_pretty_logging  # type: ignore
 from tornado.web import RequestHandler
@@ -42,7 +43,7 @@ class RedirectRequestHandler(RequestHandler):
     def initialize(self, balancer):
         self.balancer = balancer
 
-    @tornado.web.asynchronous
+    @tornado.gen.coroutine
     def get(self):
         path = self.request.path
         mode, lang_pair, per_word_modes = [None] * 3
@@ -106,7 +107,7 @@ class RedirectRequestHandler(RequestHandler):
             self.set_header(hname, hvalue)
         self.finish()
 
-    @tornado.web.asynchronous
+    @tornado.gen.coroutine
     def post(self):
         self.get()
 
@@ -120,7 +121,7 @@ class ListRequestHandler(apy.BaseHandler):
         if callbacks:
             self.callback = callbacks[0]
 
-    @tornado.web.asynchronous
+    @tornado.gen.coroutine
     def get(self):
         logging.info('Overriding list call: %s %s', self.request.path, self.get_arguments('q'))
         if self.request.path != '/listPairs' and self.request.path != '/list':

--- a/apertium_apy/handlers/base.py
+++ b/apertium_apy/handlers/base.py
@@ -5,6 +5,7 @@ import sys
 from datetime import datetime
 
 import tornado
+import tornado.gen
 import tornado.web
 from tornado.escape import utf8
 from tornado.locks import Semaphore
@@ -180,9 +181,9 @@ class BaseHandler(tornado.web.RequestHandler):
         self.set_header('Access-Control-Allow-Methods', 'GET,POST,OPTIONS')
         self.set_header('Access-Control-Allow-Headers', 'accept, cache-control, origin, x-requested-with, x-file-name, content-type')
 
-    @tornado.web.asynchronous
+    @tornado.gen.coroutine
     def post(self):
-        self.get()
+        yield self.get()
 
     def options(self):
         self.set_status(204)

--- a/apertium_apy/handlers/list_modes.py
+++ b/apertium_apy/handlers/list_modes.py
@@ -1,11 +1,11 @@
-import tornado.web
+import tornado.gen
 
 from apertium_apy.handlers.base import BaseHandler
 from apertium_apy.utils import to_alpha2_code
 
 
 class ListHandler(BaseHandler):
-    @tornado.web.asynchronous
+    @tornado.gen.coroutine
     def get(self):
         query = self.get_argument('q', default='pairs')
 

--- a/apertium_apy/handlers/stats.py
+++ b/apertium_apy/handlers/stats.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timedelta
 
-import tornado.web
+import tornado.gen
 
 from apertium_apy.handlers.base import BaseHandler
 
 
 class StatsHandler(BaseHandler):
-    @tornado.web.asynchronous
+    @tornado.gen.coroutine
     def get(self):
         num_requests = self.get_argument('requests', 1000)
         try:


### PR DESCRIPTION
should fix #148 - Fails to build with Tornado 6.x