### PR TITLE
Clarify misleading 'Serving at' info message

### DIFF
--- a/apertium_apy/apy.py
+++ b/apertium_apy/apy.py
@@ -353,10 +353,10 @@ def main():
             'certfile': args.ssl_cert,
             'keyfile': args.ssl_key,
         })
-        logging.info('Serving at https://localhost:%s', args.port)
+        logging.info('Serving on all interfaces/families, e.g. https://localhost:%s', args.port)
     else:
         http_server = tornado.httpserver.HTTPServer(application)
-        logging.info('Serving at http://localhost:%s', args.port)
+        logging.info('Serving on all interfaces/families, e.g. http://localhost:%s', args.port)
 
     signal.signal(signal.SIGTERM, sig_handler)
     signal.signal(signal.SIGINT, sig_handler)

--- a/apertium_apy/apy.py
+++ b/apertium_apy/apy.py
@@ -88,7 +88,7 @@ class GetLocaleHandler(BaseHandler):
 
 
 def setup_handler(
-    port, pairs_path, nonpairs_path, lang_names, missing_freqs_path, timeout,
+    pairs_path, nonpairs_path, lang_names, missing_freqs_path, timeout,
     max_pipes_per_pair, min_pipes_per_pair, max_users_per_pipe, max_idle_secs,
     restart_pipe_after, max_doc_pipes, verbosity=0, scale_mt_logs=False,
     memory=1000, apy_keys=None,
@@ -253,7 +253,7 @@ def setup_application(args):
     if args.stat_period_max_age:
         BaseHandler.stat_period_max_age = timedelta(0, args.stat_period_max_age, 0)
 
-    setup_handler(args.port, args.pairs_path, args.nonpairs_path, args.lang_names, args.missing_freqs, args.timeout,
+    setup_handler(args.pairs_path, args.nonpairs_path, args.lang_names, args.missing_freqs, args.timeout,
                   args.max_pipes_per_pair, args.min_pipes_per_pair, args.max_users_per_pipe, args.max_idle_secs,
                   args.restart_pipe_after, args.max_doc_pipes, args.verbosity, args.scalemt_logs,
                   args.unknown_memory_limit, args.api_keys)


### PR DESCRIPTION
`http_server.bind()` that follows the logging statements specifies just
the port, leaving address and family to their default values.

For the address argument, the default is None, meaning listening on all
available interfaces.

For the family argument, the default is AF_UNSPEC,
meaning both IPv4 and IPv6 will be used.

Clarify the comment to not mislead the user into believing the software
only binds on localhost IPv4/IPv6 addresses, but rather all interfaces
and families

While at it, drop the unused port argument of the `setup_handler()` function