### PR TITLE
Languagecode code fallback

### DIFF
--- a/apertium_apy/handlers/analyze.py
+++ b/apertium_apy/handlers/analyze.py
@@ -19,6 +19,9 @@ class AnalyzeHandler(BaseHandler):
     def get(self):
         in_text = self.get_argument('q')
         in_mode = to_alpha3_code(self.get_argument('lang'))
+        if '-' in in_mode:
+            l1, l2 = map(to_alpha3_code, in_mode.split('-'))
+            in_mode = '%s-%s' % (l1, l2)
         if in_mode in self.analyzers:
             [path, mode] = self.analyzers[in_mode]
             formatting = 'txt'

--- a/apertium_apy/handlers/analyze.py
+++ b/apertium_apy/handlers/analyze.py
@@ -20,8 +20,9 @@ class AnalyzeHandler(BaseHandler):
         in_text = self.get_argument('q')
         in_mode = to_alpha3_code(self.get_argument('lang'))
         if '-' in in_mode:
-            l1, l2 = map(to_alpha3_code, in_mode.split('-'))
+            l1, l2 = map(to_alpha3_code, in_mode.split('-', 1))
             in_mode = '%s-%s' % (l1, l2)
+        in_mode = self.find_fallback_mode(in_mode, self.analyzers)
         if in_mode in self.analyzers:
             [path, mode] = self.analyzers[in_mode]
             formatting = 'txt'

--- a/apertium_apy/handlers/coverage.py
+++ b/apertium_apy/handlers/coverage.py
@@ -10,6 +10,9 @@ class CoverageHandler(BaseHandler):
     @gen.coroutine
     def get(self):
         mode = to_alpha3_code(self.get_argument('lang'))
+        if '-' in mode:
+            l1, l2 = map(to_alpha3_code, mode.split('-'))
+            mode = '%s-%s' % (l1, l2)
         text = self.get_argument('q')
         if not text:
             self.send_error(400, explanation='Missing q argument')

--- a/apertium_apy/handlers/coverage.py
+++ b/apertium_apy/handlers/coverage.py
@@ -11,8 +11,9 @@ class CoverageHandler(BaseHandler):
     def get(self):
         mode = to_alpha3_code(self.get_argument('lang'))
         if '-' in mode:
-            l1, l2 = map(to_alpha3_code, mode.split('-'))
+            l1, l2 = map(to_alpha3_code, mode.split('-', 1))
             mode = '%s-%s' % (l1, l2)
+        mode = self.find_fallback_mode(mode, self.analyzers)
         text = self.get_argument('q')
         if not text:
             self.send_error(400, explanation='Missing q argument')

--- a/apertium_apy/handlers/generate.py
+++ b/apertium_apy/handlers/generate.py
@@ -23,6 +23,9 @@ class GenerateHandler(BaseHandler):
     def get(self):
         in_text = self.get_argument('q')
         in_mode = to_alpha3_code(self.get_argument('lang'))
+        if '-' in in_mode:
+            l1, l2 = map(to_alpha3_code, in_mode.split('-'))
+            in_mode = '%s-%s' % (l1, l2)
         if in_mode in self.generators:
             [path, mode] = self.generators[in_mode]
             formatting = 'none'

--- a/apertium_apy/handlers/generate.py
+++ b/apertium_apy/handlers/generate.py
@@ -24,8 +24,9 @@ class GenerateHandler(BaseHandler):
         in_text = self.get_argument('q')
         in_mode = to_alpha3_code(self.get_argument('lang'))
         if '-' in in_mode:
-            l1, l2 = map(to_alpha3_code, in_mode.split('-'))
+            l1, l2 = map(to_alpha3_code, in_mode.split('-', 1))
             in_mode = '%s-%s' % (l1, l2)
+        in_mode = self.find_fallback_mode(in_mode, self.generators)
         if in_mode in self.generators:
             [path, mode] = self.generators[in_mode]
             formatting = 'none'

--- a/apertium_apy/handlers/per_word.py
+++ b/apertium_apy/handlers/per_word.py
@@ -81,6 +81,9 @@ class PerWordHandler(BaseHandler):
 
     async def get(self):
         lang = to_alpha3_code(self.get_argument('lang'))
+        if '-' in lang:
+            l1, l2 = map(to_alpha3_code, lang.split('-'))
+            lang = '%s-%s' % (l1, l2)
         modes = set(self.get_argument('modes').split(' '))
         query = self.get_argument('q')
 

--- a/apertium_apy/handlers/per_word.py
+++ b/apertium_apy/handlers/per_word.py
@@ -18,15 +18,16 @@ def strip_tags(analysis):
         return analysis
 
 
-async def process_per_word(analyzers, taggers, lang, modes, query):
+async def process_per_word(self, lang, modes, query):
     outputs = {}
     morph_lexical_units = None
     tagger_lexical_units = None
     lexical_unit_re = r'\^([^\$]*)\$'
 
     if 'morph' in modes or 'biltrans' in modes:
-        if lang in analyzers:
-            mode_info = analyzers[lang]
+        lang = self.find_fallback_mode(lang, self.analyzers)
+        if lang in self.analyzers:
+            mode_info = self.analyzers[lang]
             analysis = await apertium(query, mode_info[0], mode_info[1])
             morph_lexical_units = remove_dot_from_deformat(query, re.findall(lexical_unit_re, analysis))
             outputs['morph'] = [lu.split('/')[1:] for lu in morph_lexical_units]
@@ -35,8 +36,9 @@ async def process_per_word(analyzers, taggers, lang, modes, query):
             return
 
     if 'tagger' in modes or 'disambig' in modes or 'translate' in modes:
-        if lang in taggers:
-            mode_info = taggers[lang]
+        lang = self.find_fallback_mode(lang, self.taggers)
+        if lang in self.taggers:
+            mode_info = self.taggers[lang]
             analysis = await apertium(query, mode_info[0], mode_info[1])
             tagger_lexical_units = remove_dot_from_deformat(query, re.findall(lexical_unit_re, analysis))
             outputs['tagger'] = [lu.split('/')[1:] if '/' in lu else lu for lu in tagger_lexical_units]
@@ -82,7 +84,7 @@ class PerWordHandler(BaseHandler):
     async def get(self):
         lang = to_alpha3_code(self.get_argument('lang'))
         if '-' in lang:
-            l1, l2 = map(to_alpha3_code, lang.split('-'))
+            l1, l2 = map(to_alpha3_code, lang.split('-', 1))
             lang = '%s-%s' % (l1, l2)
         modes = set(self.get_argument('modes').split(' '))
         query = self.get_argument('q')
@@ -133,5 +135,5 @@ class PerWordHandler(BaseHandler):
             else:
                 self.send_response(to_return)
 
-        output = await process_per_word(self.analyzers, self.taggers, lang, modes, query)
+        output = await process_per_word(self, lang, modes, query)
         handle_output(output)

--- a/apertium_apy/handlers/speller.py
+++ b/apertium_apy/handlers/speller.py
@@ -18,8 +18,9 @@ class SpellerHandler(BaseHandler):
         in_text = self.get_argument('q') + '*'
         in_mode = to_alpha3_code(self.get_argument('lang'))
         if '-' in in_mode:
-            l1, l2 = map(to_alpha3_code, in_mode.split('-'))
+            l1, l2 = map(to_alpha3_code, in_mode.split('-', 1))
             in_mode = '%s-%s' % (l1, l2)
+        in_mode = self.find_fallback_mode(in_mode, self.spellers)
         logging.info(in_text)
         logging.info(self.get_argument('lang'))
         logging.info(in_mode)

--- a/apertium_apy/handlers/speller.py
+++ b/apertium_apy/handlers/speller.py
@@ -17,6 +17,9 @@ class SpellerHandler(BaseHandler):
     def get(self):
         in_text = self.get_argument('q') + '*'
         in_mode = to_alpha3_code(self.get_argument('lang'))
+        if '-' in in_mode:
+            l1, l2 = map(to_alpha3_code, in_mode.split('-'))
+            in_mode = '%s-%s' % (l1, l2)
         logging.info(in_text)
         logging.info(self.get_argument('lang'))
         logging.info(in_mode)

--- a/apertium_apy/handlers/translate.py
+++ b/apertium_apy/handlers/translate.py
@@ -138,16 +138,18 @@ class TranslateHandler(BaseHandler):
     def get_pair_or_error(self, langpair, text_length):
         try:
             l1, l2 = map(to_alpha3_code, langpair.split('|'))
+            in_mode = '%s-%s' % (l1, l2)
         except ValueError:
             self.send_error(400, explanation='That pair is invalid, use e.g. eng|spa')
             self.log_after_translation(self.log_before_translation(), text_length)
             return None
-        if '%s-%s' % (l1, l2) not in self.pairs:
+        in_mode = self.find_fallback_mode(in_mode, self.pairs)
+        if in_mode not in self.pairs:
             self.send_error(400, explanation='That pair is not installed')
             self.log_after_translation(self.log_before_translation(), text_length)
             return None
         else:
-            return (l1, l2)
+            return tuple(in_mode.split('-'))
 
     def get_format(self):
         dereformat = self.get_argument('format', default=None)

--- a/apertium_apy/mode_search.py
+++ b/apertium_apy/mode_search.py
@@ -33,7 +33,7 @@ def is_loop(dirpath, rootpath, real_root=None):
 
 
 def search_path(rootpath, include_pairs=True, verbosity=1):
-    lang_code = r'[a-z]{2,3}(?:_[A-Za-z0-9]+)?'
+    lang_code = r'[a-z]{2,3}(?:_[A-Za-z0-9]+)*'
     type_re = {
         'pair': re.compile(r'({0})-({0})\.mode'.format(lang_code)),
         'analyzer': re.compile(r'(({0}(-{0})?)-(an)?mor(ph)?)\.mode'.format(lang_code)),

--- a/apertium_apy/utils/__init__.py
+++ b/apertium_apy/utils/__init__.py
@@ -30,7 +30,7 @@ def run_async_thread(func):
 
 def to_alpha2_code(code):
     if '_' in code:
-        code, variant = code.split('_')
+        code, variant = code.split('_', 1)
         return '%s_%s' % ((iso639_codes[code], variant) if code in iso639_codes else (code, variant))
     else:
         return iso639_codes[code] if code in iso639_codes else code
@@ -39,7 +39,7 @@ def to_alpha2_code(code):
 def to_alpha3_code(code):
     iso639_codes_inverse = {v: k for k, v in iso639_codes.items()}
     if '_' in code:
-        code, variant = code.split('_')
+        code, variant = code.split('_', 1)
         return '%s_%s' % ((iso639_codes_inverse[code], variant) if code in iso639_codes_inverse else (code, variant))
     else:
         return iso639_codes_inverse[code] if code in iso639_codes_inverse else code

--- a/apertium_apy/utils/__init__.py
+++ b/apertium_apy/utils/__init__.py
@@ -45,6 +45,22 @@ def to_alpha3_code(code):
         return iso639_codes_inverse[code] if code in iso639_codes_inverse else code
 
 
+def to_fallback_code(code, installed_modes):
+    if '-' in code:
+        l1, l2 = tuple(code.split('-', 1))
+        for k in range(l2.count('_') + 1):
+            for c in range(l1.count('_') + 1):
+                variant = '%s-%s' % (l1.rsplit('_', c + 1)[0], l2.rsplit('_', k)[0])
+                if variant in installed_modes:
+                    return variant
+    else:
+        for k in range(code.count('_')):
+            variant = code.rsplit('_', k + 1)[0]
+            if variant in installed_modes:
+                return variant
+    return None
+
+
 def remove_dot_from_deformat(query, analyses):
     """When using the txt format, a dot is added at EOF (also, double line
     breaks) if the last part of the query isn't itself a dot"""

--- a/apertium_apy/utils/__init__.py
+++ b/apertium_apy/utils/__init__.py
@@ -46,6 +46,10 @@ def to_alpha3_code(code):
 
 
 def to_fallback_code(code, installed_modes):
+
+    if code in installed_modes:
+        return code
+
     if '-' in code:
         l1, l2 = tuple(code.split('-', 1))
         for k in range(l2.count('_') + 1):

--- a/tests/test_fallback.py
+++ b/tests/test_fallback.py
@@ -1,0 +1,73 @@
+from unittest import TestCase
+
+from apertium_apy.utils import to_fallback_code
+
+
+class TestRootHandler(TestCase):
+    def test_existing_mode_returns(self):
+        mode = 'spa-cat_valencia_uni'
+        installed_modes = {
+            'spa-cat': '/modes/spa-cat',
+            'spa-cat_valencia': '/modes/spa-cat-valencia',
+            'spa-cat_valencia_uni': '/modes/spa-cat_valencia_uni'
+        }
+
+        output = to_fallback_code(mode, installed_modes)
+
+        self.assertEqual(output, mode)
+
+    def test_fallback_one_level(self):
+        mode = 'spa-cat_valencia_uni'
+        installed_modes = {
+            'spa-cat': '/modes/spa-cat',
+            'spa-cat_valencia': '/modes/spa-cat-valencia'
+        }
+
+        output = to_fallback_code(mode, installed_modes)
+
+        self.assertEqual(output, 'spa-cat_valencia')
+
+    def test_fallback_root(self):
+        mode = 'spa-cat_valencia_uni'
+        installed_modes = {
+            'spa-cat': '/modes/spa-cat'
+        }
+
+        output = to_fallback_code(mode, installed_modes)
+
+        self.assertEqual(output, 'spa-cat')
+
+    def test_fallback_target_has_priority(self):
+        mode = 'src_srcvariant-trg_trgvariant'
+        installed_modes = {
+            'src-trg': '/modes/src-trg',
+            'src_srcvariant-trg': '/modes/src_srcvariant-trg',
+            'src-trg_trgvariant': '/modes/src-trg_trgvariant'
+        }
+
+        output = to_fallback_code(mode, installed_modes)
+
+        self.assertEqual(output, 'src-trg_trgvariant')
+
+    def test_fallback_target_has_priority(self):
+        mode = 'src_srcvariant-trg_trgvariant'
+        installed_modes = {
+            'src-trg': '/modes/src-trg',
+            'src_srcvariant-trg': '/modes/src_srcvariant-trg',
+            'src-trg_trgvariant': '/modes/src-trg_trgvariant'
+        }
+
+        output = to_fallback_code(mode, installed_modes)
+
+        self.assertEqual(output, 'src-trg_trgvariant')
+
+    def test_two_fallbacks(self):
+        mode = 'src_srcvariant-trg_trgvariant'
+        installed_modes = {
+            'src-trg': '/modes/src-trg',
+            'src_srcvariant-trg_trgvariant': '/modes/src_srcvariant-trg_trgvariant'
+        }
+
+        output = to_fallback_code(mode, installed_modes)
+
+        self.assertEqual(output, mode)


### PR DESCRIPTION
From: https://github.com/apertium/apertium-apy/pull/181#issue-1073825658

This pull request implements language/pair code fallback when an exact mode match is not found. The target language has priority over the source language when looking for a valid mode. All functions with language codes support this, except for `translateChain` (should not be impossible to implement, but it is harder). This should specially benefit the users of CAT tools such as OmegaT or Okapi Framework, where language-country codes are frequent.

When a request is received and a matching mode is not found, the API now checks a temporary list of equivalents. If there is no match there either, it strips variant codes one by one to try to find an installed mode. If there is a match, it is cached in the temporary list for faster retrieval later. If there is no match anywhere, the usual "This pair is not installed" message is returned.

In addition, this includes two other fixes:

1. The mode search was truncating modes with more than one variant ("_"). This caused many modes to be unavailable (see #141).
2. Many API functions were not handling 2-letter codes properly. All functions should now convert 2-letter codes to 3-letter codes if available (for example, when requesting `analyze` to a language pair such as `es-ca`, which will now become `spa-cat`.

Closes #141 
Closes #174 