### PR TITLE
MIME identification using python

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ chardet = "*"
 requests = "*"
 tornado = "==6.0.3"
 commentjson = "*"
+python-magic = "*"
 
 [dev-packages]
 coverage = "*"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ of the following packages:
 - `chromium_compact_language_detector` enables improved language detection (cld2)
 - `chardet` enables website character encoding detection
 - `commentjson` allows to keep API keys in commented json
+- `python-magic` allows file type detection
 
 Precise versions are available in `requirements.txt` and `setup.py`.
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'suggestions': ['requests'],
         'website_encoding_detect': ['chardet'],
         'lang_detect': ['chromium_compact_language_detector'],
-        'full': ['apertium-streamparser', 'requests', 'chardet', 'chromium_compact_language_detector', 'commentjson'],
+        'full': ['apertium-streamparser', 'requests', 'chardet', 'chromium_compact_language_detector', 'commentjson', 'python-magic'],
     },
     entry_points={
         'console_scripts': ['apertium-apy=apertium_apy.apy:main'],


### PR DESCRIPTION
Fixes #47 
Earlier subprocesses mimetype/xdg-mime/file were being used to detect MIME type which could lead to security issues so now then have been switched with python-magic a library used to detect MIME type within python.